### PR TITLE
Replace stub/virtualize usage with mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ Alternatively you can also use [grpcui](https://github.com/fullstorydev/grpcui) 
 grpcui -plaintext localhost:8085
 ```
 
-Also observe corresponding logs in the Specmatic Stub Server which is emulating domain service to understand the interactions between BFF and Domain and Service.
+Also observe corresponding logs in the specmatic mock Server which is emulating domain service to understand the interactions between BFF and Domain and Service.

--- a/src/test/kotlin/com/store/order/bff/ContractTestUsingTestContainer.kt
+++ b/src/test/kotlin/com/store/order/bff/ContractTestUsingTestContainer.kt
@@ -28,7 +28,7 @@ class ContractTestUsingTestContainer {
                 .withFileSystemBind("./src", "/usr/src/app/src", BindMode.READ_ONLY)
                 .withFileSystemBind("./specmatic.yaml", "/usr/src/app/specmatic.yaml", BindMode.READ_ONLY)
                 .withNetworkMode("host")
-                .waitingFor(Wait.forLogMessage(".*gRPC Stub server is running on.*", 1))
+                .waitingFor(Wait.forLogMessage(".*gRPC Mock server is running on.*", 1))
                 .withLogConsumer { print(it.utf8String) }
     }
 

--- a/src/test/kotlin/com/store/order/bff/ContractTestUsingTestContainer.kt
+++ b/src/test/kotlin/com/store/order/bff/ContractTestUsingTestContainer.kt
@@ -28,7 +28,7 @@ class ContractTestUsingTestContainer {
                 .withFileSystemBind("./src", "/usr/src/app/src", BindMode.READ_ONLY)
                 .withFileSystemBind("./specmatic.yaml", "/usr/src/app/specmatic.yaml", BindMode.READ_ONLY)
                 .withNetworkMode("host")
-                .waitingFor(Wait.forLogMessage(".*gRPC Mock server is running on.*", 1))
+                .waitingFor(Wait.forLogMessage(".*\\[Specmatic gRPC\\] Server started, listening on.*", 1))
                 .withLogConsumer { print(it.utf8String) }
     }
 


### PR DESCRIPTION
## Summary
- replace remaining Specmatic command usage of \ and \ with \
- update test-container startup checks to match mock server logs where applicable

## Validation
- searched codebase for remaining command-form usage of \Using bleeding edge Specmatic build

Error: No jar file found matching pattern: /Users/naresh/projects/specmatic-all/specmatic/application/build/libs/specmatic*-all-un*.jar and \