### PR TITLE
refactor: use shared orchestrator setup action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,12 +35,6 @@ jobs:
       with:
         submodules: 'true'
 
-    - name: Add orchestrator context to summary
-      if: ${{ inputs.orchestrator_run_suffix != '' }}
-      run: |
-        echo "### Orchestrator" >> "$GITHUB_STEP_SUMMARY"
-        echo "Run: ${{ inputs.orchestrator_run_suffix }}" >> "$GITHUB_STEP_SUMMARY"
-
     - name: Set up JDK 17
       uses: actions/setup-java@v5
       with:
@@ -59,27 +53,15 @@ jobs:
         echo "${{ secrets.SPECMATIC_LICENSE_KEY }}" > ~/.specmatic/specmatic-license.txt
 
     # Start: internal setup required by Specmatic. Sample project users can ignore this block.
-    - name: Install Gradle snapshot init script
-      if: ${{ inputs.orchestrator_run_suffix != '' && github.ref == 'refs/heads/main' }}
-      shell: bash
-      run: |
-        set -euo pipefail
-
-        mkdir -p "$HOME/.gradle/init.d"
-        cp ./gradle/specmatic-snapshots.init.gradle "$HOME/.gradle/init.d/specmatic-snapshots.init.gradle"
-
-    - name: Docker Login for orchestrator snapshot image
-      if: ${{ inputs.orchestrator_run_suffix != '' && github.ref == 'refs/heads/main' }}
-      run: echo ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }} | docker login -u ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }} --password-stdin
-
-    - name: Prepare snapshot image for orchestrator run
-      if: ${{ inputs.orchestrator_run_suffix != '' && github.ref == 'refs/heads/main' }}
-      shell: bash
-      run: |
-        set -euo pipefail
-
-        docker pull specmatic/enterprise-snapshot
-        docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest
+    - if: ${{ inputs.orchestrator_run_suffix != '' }}
+      uses: specmatic/specmatic-github-workflows/action-orchestrator-setup@main
+      with:
+        orchestrator-run-suffix: ${{ inputs.orchestrator_run_suffix }}
+        enterprise-version: ${{ inputs.enterprise_version }}
+        gradle-snapshot-init-script-path: ./gradle/specmatic-snapshots.init.gradle
+        docker-hub-username: ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }}
+        docker-hub-token: ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }}
+        setup-snapshot-docker-image: 'true'
     # End: internal setup required by Specmatic.
 
     - name: Build with Gradle Wrapper

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       enterprise_artifact_url:
-        description: Specmatic enterprise jar/artifact URL under test
+        description: Specmatic Enterprise jar/artifact URL under test
         required: false
         type: string
       orchestrator_run_suffix:
@@ -29,8 +29,6 @@ jobs:
       contents: read
     env:
       CTRF_RESULT_PATH: "build/reports/specmatic/grpc/test/ctrf/*.json"
-      ENTERPRISE_VERSION: ${{ inputs.enterprise_version }}
-      ENTERPRISE_ARTIFACT_URL: ${{ inputs.enterprise_artifact_url }}
 
     steps:
     - uses: actions/checkout@v6
@@ -60,45 +58,36 @@ jobs:
         mkdir -p ~/.specmatic
         echo "${{ secrets.SPECMATIC_LICENSE_KEY }}" > ~/.specmatic/specmatic-license.txt
 
-    - name: Prepare Specmatic Enterprise artifact
-      if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
+    # Start: internal setup required by Specmatic. Sample project users can ignore this block.
+    - name: Install Gradle snapshot init script
+      if: ${{ inputs.orchestrator_run_suffix != '' && github.ref == 'refs/heads/main' }}
       shell: bash
       run: |
         set -euo pipefail
 
-        mkdir -p ~/.specmatic
-        url="${ENTERPRISE_ARTIFACT_URL}"
-        output_path="$HOME/.specmatic/specmatic-enterprise.jar"
-        echo "Downloading Enterprise artifact from:"
-        echo "$url"
+        mkdir -p "$HOME/.gradle/init.d"
+        cp ./gradle/specmatic-snapshots.init.gradle "$HOME/.gradle/init.d/specmatic-snapshots.init.gradle"
 
-        initial_sleep=$(( RANDOM % 31 ))
-        echo "Initial jitter: ${initial_sleep}s"
-        sleep "$initial_sleep"
-
-        echo "Download attempt 1/1"
-        curl --http1.1 -L --fail --continue-at - "$url" -o "$output_path"
-        echo "Enterprise artifact downloaded successfully"
-
-        mvn install:install-file \
-          -Dfile="$HOME/.specmatic/specmatic-enterprise.jar" \
-          -DgroupId=io.specmatic.enterprise \
-          -DartifactId=executable \
-          -Dversion="${ENTERPRISE_VERSION}" \
-          -Dpackaging=jar \
-          -DgeneratePom=true
-
-        echo "Installed Enterprise artifact into local Maven"
-
-    - name: Docker Login
-      if: ${{ matrix.name == 'docker' && inputs.enterprise_artifact_url != '' && github.ref == 'refs/heads/main' }}
+    - name: Docker Login for orchestrator snapshot image
+      if: ${{ inputs.orchestrator_run_suffix != '' && github.ref == 'refs/heads/main' }}
       run: echo ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }} | docker login -u ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }} --password-stdin
 
+    - name: Prepare snapshot image for orchestrator run
+      if: ${{ inputs.orchestrator_run_suffix != '' && github.ref == 'refs/heads/main' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        docker pull specmatic/enterprise-snapshot
+        docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest
+    # End: internal setup required by Specmatic.
+
     - name: Build with Gradle Wrapper
+      env:
+        ENTERPRISE_VERSION: ${{ inputs.enterprise_version }}
       run: |
         ./gradlew clean test \
-          ${ENTERPRISE_VERSION:+-PspecmaticEnterpriseVersion=${ENTERPRISE_VERSION}} \
-          ${ENTERPRISE_VERSION:+-PenterpriseVersion=${ENTERPRISE_VERSION}}
+          ${ENTERPRISE_VERSION:+-PspecmaticEnterpriseVersion=${ENTERPRISE_VERSION}}
 
     - name: Upload CTRF Report
       uses: actions/upload-artifact@v6

--- a/gradle/specmatic-snapshots.init.gradle
+++ b/gradle/specmatic-snapshots.init.gradle
@@ -1,0 +1,10 @@
+allprojects {
+    repositories {
+        maven {
+            url = uri("https://central.sonatype.com/repository/maven-snapshots")
+            mavenContent {
+                snapshotsOnly()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace inline orchestrator setup steps with the shared action
- keep the existing Gradle snapshot init wiring in place where needed
- reduce duplicated workflow logic across sample projects